### PR TITLE
Fixed wrong access on constructor

### DIFF
--- a/app/src/main/java/com/xmartlabs/moviefan/ui/recyclerview/OnDemandRecyclerViewScrollListener.java
+++ b/app/src/main/java/com/xmartlabs/moviefan/ui/recyclerview/OnDemandRecyclerViewScrollListener.java
@@ -24,7 +24,7 @@ public abstract class OnDemandRecyclerViewScrollListener extends RecyclerView.On
   @Setter
   private int visibleThreshold = VISIBLE_THRESHOLD_DEFAULT;
 
-  private OnDemandRecyclerViewScrollListener() {
+  protected OnDemandRecyclerViewScrollListener() {
     loadNextPage(page);
   }
 


### PR DESCRIPTION
In the last PR the OnDemandRecyclerViewScrollListener constructor was changed from `public` to `private`. That change was wrong, as another class in the same package was making use of it. It's fixed now as it only needed a change to `protected`.

/cc @xmartlabs/android
