### PR TITLE
Fixing repeating detailed viewholders

### DIFF
--- a/app/src/main/java/com/xmartlabs/moviefan/ui/main/FilmsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/xmartlabs/moviefan/ui/main/FilmsRecyclerViewAdapter.java
@@ -49,7 +49,7 @@ public class FilmsRecyclerViewAdapter extends BaseRecyclerViewAdapter {
       };
 
   @MainThread
-  void setItems(@NonNull List<Film> films) {
+  void addItems(@NonNull List<Film> films) {
     int detailedViewholdersToBeAdded = Math.max(0, DETAILED_FILM_VIEWHOLDER_LIMIT - getItems().size());
 
     Stream.of(films)

--- a/app/src/main/java/com/xmartlabs/moviefan/ui/main/FilmsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/xmartlabs/moviefan/ui/main/FilmsRecyclerViewAdapter.java
@@ -50,14 +50,14 @@ public class FilmsRecyclerViewAdapter extends BaseRecyclerViewAdapter {
 
   @MainThread
   void setItems(@NonNull List<Film> films) {
-    int remainingDetailedViewholders = Math.max(0, DETAILED_FILM_VIEWHOLDER_LIMIT - getItems().size());
+    int detailedViewholdersToBeAdded = Math.max(0, DETAILED_FILM_VIEWHOLDER_LIMIT - getItems().size());
 
     Stream.of(films)
-        .limit(remainingDetailedViewholders)
+        .limit(detailedViewholdersToBeAdded)
         .forEach(film -> addItemWithoutNotifying(detailedItemType, film, true));
 
     Stream.of(films)
-        .skip(remainingDetailedViewholders)
+        .skip(detailedViewholdersToBeAdded)
         .forEach(film -> addItemWithoutNotifying(collapsedItemType, film, true));
 
     notifyDataSetChanged();

--- a/app/src/main/java/com/xmartlabs/moviefan/ui/main/FilmsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/xmartlabs/moviefan/ui/main/FilmsRecyclerViewAdapter.java
@@ -50,12 +50,14 @@ public class FilmsRecyclerViewAdapter extends BaseRecyclerViewAdapter {
 
   @MainThread
   void setItems(@NonNull List<Film> films) {
+    int remainingDetailedViewholders = Math.max(0, DETAILED_FILM_VIEWHOLDER_LIMIT - getItems().size());
+
     Stream.of(films)
-        .limit(DETAILED_FILM_VIEWHOLDER_LIMIT)
+        .limit(remainingDetailedViewholders)
         .forEach(film -> addItemWithoutNotifying(detailedItemType, film, true));
 
     Stream.of(films)
-        .skip(DETAILED_FILM_VIEWHOLDER_LIMIT)
+        .skip(remainingDetailedViewholders)
         .forEach(film -> addItemWithoutNotifying(collapsedItemType, film, true));
 
     notifyDataSetChanged();

--- a/app/src/main/java/com/xmartlabs/moviefan/ui/main/MovieFanPageBaseFragment.java
+++ b/app/src/main/java/com/xmartlabs/moviefan/ui/main/MovieFanPageBaseFragment.java
@@ -50,7 +50,7 @@ public abstract class MovieFanPageBaseFragment<V extends MovieFanPageBaseView, P
   @Override
   public void addFilmsAndNotifyAdapter(@NonNull List<Film> films) {
     //noinspection ConstantConditions
-    adapter.setItems(films);
+    adapter.addItems(films);
     adapter.notifyDataSetChanged();
   }
 


### PR DESCRIPTION
The limit for detailed viewholder items in the app is 3. If you scrolled enough, the detailed viewholder was repeated every 20 items (each new page allocated 3 detailed viewholder items, when only 3 needed to be displayed in the entire tab). This PR fixes that issue.

### UI preview:
<p align="center">
  <img src="http://g.recordit.co/IgWHGs0PZC.gif"/>
</p>

/cc @xmartlabs/android